### PR TITLE
Add Passthrough transforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
-
 language: objective-c
 osx_image: xcode8.3
 
 script:
 - set -o pipefail
 - ./Scripts/test
+
+after_success:
+- bash <(curl -s https://codecov.io/bash)

--- a/Mortar.xcodeproj/project.pbxproj
+++ b/Mortar.xcodeproj/project.pbxproj
@@ -22,6 +22,9 @@
 		9A49DC851EC4D2510053710B /* TestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A49DC841EC4D2510053710B /* TestError.swift */; };
 		9A49DC881EC4D3290053710B /* Types.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A49DC871EC4D3290053710B /* Types.swift */; };
 		9A5C46F01EC72E9A00CE3627 /* ExclusiveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A5C46EF1EC72E9A00CE3627 /* ExclusiveTests.swift */; };
+		9AE2A1C91ECA456E00921247 /* Passthrough.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AE2A1C81ECA456E00921247 /* Passthrough.swift */; };
+		9AE2A1CA1ECA456F00921247 /* Passthrough.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AE2A1C81ECA456E00921247 /* Passthrough.swift */; };
+		9AE2A1CC1ECB189C00921247 /* PassthroughTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AE2A1CB1ECB189C00921247 /* PassthroughTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -50,6 +53,8 @@
 		9A49DC841EC4D2510053710B /* TestError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestError.swift; sourceTree = "<group>"; };
 		9A49DC871EC4D3290053710B /* Types.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Types.swift; sourceTree = "<group>"; };
 		9A5C46EF1EC72E9A00CE3627 /* ExclusiveTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExclusiveTests.swift; sourceTree = "<group>"; };
+		9AE2A1C81ECA456E00921247 /* Passthrough.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Passthrough.swift; sourceTree = "<group>"; };
+		9AE2A1CB1ECB189C00921247 /* PassthroughTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PassthroughTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -116,6 +121,7 @@
 				9A49DC861EC4D31F0053710B /* Test Suite */,
 				9A49DC5B1EC49A170053710B /* CompositionalTests.swift */,
 				9A5C46EF1EC72E9A00CE3627 /* ExclusiveTests.swift */,
+				9AE2A1CB1ECB189C00921247 /* PassthroughTests.swift */,
 				9A49DC5D1EC49A170053710B /* Info.plist */,
 			);
 			path = MortarTests;
@@ -126,6 +132,7 @@
 			children = (
 				9A49DC781EC49BDB0053710B /* Compositional.swift */,
 				9A49DC7B1EC49C520053710B /* Exclusive.swift */,
+				9AE2A1C81ECA456E00921247 /* Passthrough.swift */,
 			);
 			name = Transforms;
 			sourceTree = "<group>";
@@ -290,6 +297,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9AE2A1C91ECA456E00921247 /* Passthrough.swift in Sources */,
 				9A49DC801EC49C730053710B /* FunctionTypes.swift in Sources */,
 				9A49DC731EC49BA30053710B /* Result.swift in Sources */,
 				9A49DC7C1EC49C520053710B /* Exclusive.swift in Sources */,
@@ -304,6 +312,7 @@
 				9A49DC881EC4D3290053710B /* Types.swift in Sources */,
 				9A49DC851EC4D2510053710B /* TestError.swift in Sources */,
 				9A5C46F01EC72E9A00CE3627 /* ExclusiveTests.swift in Sources */,
+				9AE2A1CC1ECB189C00921247 /* PassthroughTests.swift in Sources */,
 				9A49DC5C1EC49A170053710B /* CompositionalTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -312,6 +321,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9AE2A1CA1ECA456F00921247 /* Passthrough.swift in Sources */,
 				9A49DC811EC49C730053710B /* FunctionTypes.swift in Sources */,
 				9A49DC741EC49BA30053710B /* Result.swift in Sources */,
 				9A49DC7D1EC49C520053710B /* Exclusive.swift in Sources */,

--- a/Mortar/FunctionTypes.swift
+++ b/Mortar/FunctionTypes.swift
@@ -29,3 +29,4 @@ import Foundation
 public typealias AsyncTransform<X, Y, E: Error>  = (_ input: X, _ output: @escaping (Result<Y, E>) -> Void) -> Void
 public typealias Transform<X, Y, E: Error>       = (_ input: X) -> Result<Y, E>
 public typealias SimpleTransform<X, Y>           = (_ input: X) -> Y
+public typealias PassTransform<X>                = (_ input: X) -> Void

--- a/Mortar/Passthrough.swift
+++ b/Mortar/Passthrough.swift
@@ -1,21 +1,21 @@
 //
-//  TestError.swift
-//  MortarTests
+//  Passthrough.swift
+//  Mortar
 //
 //  The MIT License (MIT)
-//  
+//
 //  Copyright (c) 2017 Dima Bart
-//  
+//
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
 //  in the Software without restriction, including without limitation the rights
 //  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 //  copies of the Software, and to permit persons to whom the Software is
 //  furnished to do so, subject to the following conditions:
-//  
+//
 //  The above copyright notice and this permission notice shall be included in all
 //  copies or substantial portions of the Software.
-//  
+//
 //  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 //  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 //  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,6 +26,45 @@
 
 import Foundation
 
-enum TestError: Error {
-    case generic
+// ----------------------------------
+//  MARK: - Operator -
+//
+infix operator -<: AdditionPrecedence
+
+// ----------------------------------
+//  MARK: - Overloads -
+//
+public func -< <X, Y, E>(lhs: @escaping AsyncTransform<X, Y, E>, rhs: @escaping PassTransform<Y>) -> AsyncTransform<X, Y, E> {
+    return { x, completion in
+        lhs(x) { result in
+            switch result {
+            case .success(let y):
+                rhs(y)
+                completion(.success(y))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+}
+
+public func -< <X, Y, E>(lhs: @escaping Transform<X, Y, E>, rhs: @escaping PassTransform<Y>) -> Transform<X, Y, E> {
+    return { x in
+        let result = lhs(x)
+        switch result {
+        case .success(let y):
+            rhs(y)
+        default:
+            break
+        }
+        return result
+    }
+}
+
+public func -< <X, Y>(lhs: @escaping SimpleTransform<X, Y>, rhs: @escaping PassTransform<Y>) -> SimpleTransform<X, Y> {
+    return { x in
+        let y = lhs(x)
+        rhs(y)
+        return y
+    }
 }

--- a/MortarTests/ExclusiveTests.swift
+++ b/MortarTests/ExclusiveTests.swift
@@ -1,6 +1,6 @@
 //
 //  ExclusiveTests.swift
-//  Mortar
+//  MortarTests
 //
 //  The MIT License (MIT)
 //

--- a/MortarTests/PassthroughTests.swift
+++ b/MortarTests/PassthroughTests.swift
@@ -1,0 +1,107 @@
+//
+//  PassthroughTests.swift
+//  MortarTests
+//
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2017 Dima Bart
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
+import XCTest
+import Mortar
+
+class PassthroughTests: XCTestCase {
+
+    // ----------------------------------
+    //  MARK: - Passthrough -
+    //
+    func testAsyncPassthroughSuccess() {
+        
+        var didLog = false
+        
+        let log: T_PassthroughInt = { value in
+            didLog = true
+            XCTAssertEqual(value, 5)
+        }
+        
+        let pipeline = addTwo_s -< log <<- stringify_s
+        pipeline(3) { _ in }
+        
+        XCTAssertTrue(didLog)
+    }
+    
+    func testAsyncPassthroughFailure() {
+        
+        var didLog = false
+        
+        let log: T_PassthroughInt = { value in
+            didLog = true
+        }
+        
+        let pipeline = addTwo_f -< log <<- stringify_s
+        pipeline(3) { _ in }
+        
+        XCTAssertFalse(didLog)
+    }
+    
+    func testSyncPassthroughSuccess() {
+        
+        var didLog = false
+        
+        let log: T_PassthroughInt = { value in
+            didLog = true
+            XCTAssertEqual(value, 6)
+        }
+        
+        let pipeline = double_s -< log <<- stringify_s
+        pipeline(3) { _ in }
+        
+        XCTAssertTrue(didLog)
+    }
+    
+    func testSyncPassthroughFailure() {
+        
+        var didLog = false
+        
+        let log: T_PassthroughInt = { value in
+            didLog = true
+        }
+        
+        let pipeline = double_f -< log <<- stringify_s
+        pipeline(3) { _ in }
+        
+        XCTAssertFalse(didLog)
+    }
+    
+    func testSimplePassthroughSuccess() {
+        
+        var didLog = false
+        
+        let log: T_PassthroughInt = { value in
+            didLog = true
+            XCTAssertEqual(value, 9)
+        }
+        
+        let pipeline = triple_s -< log <<- stringify_s
+        pipeline(3) { _ in }
+        
+        XCTAssertTrue(didLog)
+    }
+}

--- a/MortarTests/Types.swift
+++ b/MortarTests/Types.swift
@@ -1,6 +1,6 @@
 //
 //  Types.swift
-//  Mortar
+//  MortarTests
 //
 //  The MIT License (MIT)
 //  
@@ -38,6 +38,9 @@ typealias T_SyncIntToString     = (Int) -> Result<String, TestError>
 
 typealias T_SimpleIntToInt      = (Int) -> Int
 typealias T_SimpleIntToString   = (Int) -> String
+
+typealias T_PassthroughInt      = (Int) -> Void
+typealias T_PassthroughString   = (String) -> Void
 
 // ----------------------------------
 //  MARK: - Functions -

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Mortar
 
 [![Build Status](https://travis-ci.org/dbart01/Mortar.svg?branch=master)](https://travis-ci.org/dbart01/Mortar)
+[![codecov](https://codecov.io/gh/dbart01/Mortar/branch/master/graph/badge.svg)](https://codecov.io/gh/dbart01/Mortar)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![GitHub release](https://img.shields.io/github/release/dbart01/mortar.svg)](https://github.com/dbart01/Mortar/releases/latest)
 [![GitHub license](https://img.shields.io/badge/license-MIT-orange.svg)](https://github.com/dbart01/Mortar/blob/master/LICENSE)


### PR DESCRIPTION
### What this does

Adds passthrough transforms for combining with any of the existing three transformation. Can be used for silently intercepting the result of the previous transform.

### Other notable changes
- adds Codecov support